### PR TITLE
Removed debugging output from install script

### DIFF
--- a/FarmData2/features/install-features-into-client/run.sh
+++ b/FarmData2/features/install-features-into-client/run.sh
@@ -13,10 +13,8 @@ done
 
 ## Install features into the client.
 for feature in ./.kit/features/* ; do
-    pwd
     script="$feature"/install-into-client.sh
     if [[ -e "$script" ]] ; then
-        echo "$scipt"
         "$script"
     fi
 done


### PR DESCRIPTION
Removes the debugging `pwd` and `echo "$script"` lines from `run.sh`.  These generated a lot of output when a student would clone the FarmData2 repo into the KitClient.  This was causing the git kit-tty output to be lost in the noise.

* Closes #10